### PR TITLE
[PHEE-606] Update setup_remote_docker version for CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-          version: 20.10.14
+          version: 20.10.24
       - run:
           name: Build and Push Docker tag Image
           command: |
@@ -51,7 +51,7 @@ jobs:
       - checkout
       # Install Docker to build and push the image
       - setup_remote_docker:
-          version: 20.10.14
+          version: 20.10.24
 
       # Build the Docker image
       - run:


### PR DESCRIPTION
(https://fynarfin.atlassian.net/browse/PHEE-606)
## Description

- This job was rejected because the image is unavailable.(20.10.14)
- Updated with new version 20.10.24

