### PR TITLE
Release mifos-v2.0.0: Java 17 migration and Mifos JFrog dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ orbs:
 executors:
   docker-executor:
     docker:
-      - image: circleci/openjdk:17-buster-node-browsers-legacy
+      - image: eclipse-temurin:17-jdk
 jobs:
   build_and_push_tag_image:
     executor: docker-executor
@@ -23,6 +23,18 @@ jobs:
             echo "export DOCKER_REPO_LOWER=$(echo $CIRCLE_PROJECT_REPONAME | tr '[:upper:]' '[:lower:]')" >> $BASH_ENV
             echo "Using Docker Namespace: $DOCKER_ORG_LOWER"
             echo "Using Docker Repository: $DOCKER_REPO_LOWER"
+      - run:
+          name: Install Docker CLI
+          command: |
+            apt-get update
+            apt-get install -y curl ca-certificates gnupg
+            install -m 0755 -d /etc/apt/keyrings
+            curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc
+            chmod a+r /etc/apt/keyrings/docker.asc
+            echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian bullseye stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
+            apt-get update
+            apt-cache madison docker-ce-cli | grep 20.10
+            apt-get install -y docker-ce-cli=5:20.10.24~3-0~debian-bullseye
       - docker-buildx/install
       - run:
           name: Check if Docker image tag exists
@@ -64,6 +76,18 @@ jobs:
             echo "export DOCKER_REPO_LOWER=$(echo $CIRCLE_PROJECT_REPONAME | tr '[:upper:]' '[:lower:]')" >> $BASH_ENV
             echo "Using Docker Namespace: $DOCKER_ORG_LOWER"
             echo "Using Docker Repository: $DOCKER_REPO_LOWER"
+      - run:
+          name: Install Docker CLI
+          command: |
+            apt-get update
+            apt-get install -y curl ca-certificates gnupg
+            install -m 0755 -d /etc/apt/keyrings
+            curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc
+            chmod a+r /etc/apt/keyrings/docker.asc
+            echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian bullseye stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
+            apt-get update
+            apt-cache madison docker-ce-cli | grep 20.10
+            apt-get install -y docker-ce-cli=5:20.10.24~3-0~debian-bullseye
       - docker-buildx/install
       - run:
           name: Build Application
@@ -101,6 +125,18 @@ jobs:
             echo "export DOCKER_REPO_LOWER=$(echo $CIRCLE_PROJECT_REPONAME | tr '[:upper:]' '[:lower:]')" >> $BASH_ENV
             echo "Using Docker Namespace: $DOCKER_ORG_LOWER"
             echo "Using Docker Repository: $DOCKER_REPO_LOWER"
+      - run:
+          name: Install Docker CLI
+          command: |
+            apt-get update
+            apt-get install -y curl ca-certificates gnupg
+            install -m 0755 -d /etc/apt/keyrings
+            curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc
+            chmod a+r /etc/apt/keyrings/docker.asc
+            echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian bullseye stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
+            apt-get update
+            apt-cache madison docker-ce-cli | grep 20.10
+            apt-get install -y docker-ce-cli=5:20.10.24~3-0~debian-bullseye
       - docker-buildx/install
       - run:
           name: Build Application

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,102 +1,150 @@
 version: 2.1
+orbs:
+  docker-buildx: devarsh/docker-buildx-orb@0.1.1
 executors:
   docker-executor:
     docker:
       - image: circleci/openjdk:17-buster-node-browsers-legacy
-        auth:
-          username: $DOCKERHUB_USERNAME
-          password: $DOCKERHUB_PASSWORD
-
 jobs:
   build_and_push_tag_image:
     executor: docker-executor
     environment:
       JVM_OPTS: -Xmx512m
       TERM: dumb
-      GITHUB_TOKEN: ${GITHUB_TOKEN}  # Add the GitHub token as an environment variable
-
     steps:
       - checkout
       - setup_remote_docker:
-          version: 20.10.14
+          version: 20.10.24
       - run:
-          name: Build and Push Docker tag Image
+          name: Set Lowercase Docker Image Vars
+          # Using tr for POSIX compatibility, could use ${VAR,,} with Bash 4+
           command: |
-            # Set environment variables
+            echo "export DOCKER_ORG_LOWER=$(echo $CIRCLE_PROJECT_USERNAME | tr '[:upper:]' '[:lower:]')" >> $BASH_ENV
+            echo "export DOCKER_REPO_LOWER=$(echo $CIRCLE_PROJECT_REPONAME | tr '[:upper:]' '[:lower:]')" >> $BASH_ENV
+            echo "Using Docker Namespace: $DOCKER_ORG_LOWER"
+            echo "Using Docker Repository: $DOCKER_REPO_LOWER"
+      - docker-buildx/install
+      - run:
+          name: Check if Docker image tag exists
+          command: |
             IMAGE_TAG=$CIRCLE_TAG
-
-            # Check if the Docker image with the same tag already exists in Docker Hub
-            if curl -s -f -u "$DOCKERHUB_USERNAME":"$DOCKERHUB_PASSWORD" "https://hub.docker.com/v2/repositories/openmf/ph-ee-bill-pay/tags/$IMAGE_TAG" > /dev/null; then
-              echo "Skipping the build and push as the tag $IMAGE_TAG already exists in Docker Hub."
-              exit 0
+            # Using lowercase variables defined above
+            IMAGE_NAME="$DOCKER_ORG_LOWER/$DOCKER_REPO_LOWER"
+            echo "Checking for Docker image: $IMAGE_NAME:$IMAGE_TAG"
+            # Ensure DOCKERHUB_USERNAME and DOCKERHUB_PASSWORD are set in your CircleCI Context or Project Environment Variables
+            if curl -s -f -u "$DOCKERHUB_USERNAME":"$DOCKERHUB_PASSWORD" "https://hub.docker.com/v2/repositories/$IMAGE_NAME/tags/$IMAGE_TAG" > /dev/null; then
+              echo "Skipping the build and push as the tag $IMAGE_TAG already exists in Docker Hub for image $IMAGE_NAME."
+              circleci-agent step halt
+            else
+              echo "Tag $IMAGE_TAG does not exist for image $IMAGE_NAME. Proceeding with build."
             fi
-
-            # Build and tag the Docker image
-            ./gradlew bootJar
-            docker build -t "openmf/ph-ee-bill-pay:$IMAGE_TAG" .
-
-            # Push the Docker image to Docker Hub
-            docker login -u "$DOCKERHUB_USERNAME" -p "$DOCKERHUB_PASSWORD"
-            docker push "openmf/ph-ee-bill-pay:$IMAGE_TAG"
-
-          # when: always  # The job will be executed even if there's no match for the tag filter
-
+      - run:
+          name: Build Application
+          command: ./gradlew bootJar
+      - docker-buildx/build-and-push:
+          # Using lowercase variables defined above
+          image-name: "$DOCKER_ORG_LOWER/$DOCKER_REPO_LOWER"
+          tag: "$CIRCLE_TAG"
+          # Add dockerhub credentials if needed
+          # dockerhub-username: "$DOCKERHUB_USERNAME"
+          # dockerhub-password: "$DOCKERHUB_PASSWORD"
+  build_and_push_branch_image:
+    executor: docker-executor
+    environment:
+      JVM_OPTS: -Xmx512m
+      TERM: dumb
+    steps:
+      - checkout
+      - setup_remote_docker:
+          version: 20.10.24
+      - run:
+          name: Set Lowercase Docker Image Vars
+          command: |
+            echo "export DOCKER_ORG_LOWER=$(echo $CIRCLE_PROJECT_USERNAME | tr '[:upper:]' '[:lower:]')" >> $BASH_ENV
+            echo "export DOCKER_REPO_LOWER=$(echo $CIRCLE_PROJECT_REPONAME | tr '[:upper:]' '[:lower:]')" >> $BASH_ENV
+            echo "Using Docker Namespace: $DOCKER_ORG_LOWER"
+            echo "Using Docker Repository: $DOCKER_REPO_LOWER"
+      - docker-buildx/install
+      - run:
+          name: Build Application
+          command: |
+            ./gradlew checkstyleMain
+            ./gradlew clean bootJar
+      - run:
+          name: Sanitize Branch Name
+          command: |
+            echo "export SANITIZED_BRANCH=$(echo $CIRCLE_BRANCH | sed 's/[^a-zA-Z0-9.-]/-/g' | tr '[:upper:]' '[:lower:]')" >> $BASH_ENV # Also ensure branch tag is lowercase
+      # First build and push with branch-latest tag
+      - docker-buildx/build-and-push:
+          image-name: "$DOCKER_ORG_LOWER/$DOCKER_REPO_LOWER"
+          tag: "${SANITIZED_BRANCH}-latest"
+      # Then build and push with branch-version tag
+      - docker-buildx/build-and-push:
+          image-name: "$DOCKER_ORG_LOWER/$DOCKER_REPO_LOWER"
+          tag: "${SANITIZED_BRANCH}"
+          # Add dockerhub credentials if needed
+          # dockerhub-username: "$DOCKERHUB_USERNAME"
+          # dockerhub-password: "$DOCKERHUB_PASSWORD"
   build_and_push_latest_image:
     executor: docker-executor
     environment:
       JVM_OPTS: -Xmx512m
       TERM: dumb
-
     steps:
       - checkout
-      # Install Docker to build and push the image
       - setup_remote_docker:
-          version: 20.10.14
-
-      # Build the Docker image
+          version: 20.10.24
       - run:
-          name: Build Docker image
+          name: Set Lowercase Docker Image Vars
+          command: |
+            echo "export DOCKER_ORG_LOWER=$(echo $CIRCLE_PROJECT_USERNAME | tr '[:upper:]' '[:lower:]')" >> $BASH_ENV
+            echo "export DOCKER_REPO_LOWER=$(echo $CIRCLE_PROJECT_REPONAME | tr '[:upper:]' '[:lower:]')" >> $BASH_ENV
+            echo "Using Docker Namespace: $DOCKER_ORG_LOWER"
+            echo "Using Docker Repository: $DOCKER_REPO_LOWER"
+      - docker-buildx/install
+      - run:
+          name: Build Application
           command: |
             ./gradlew checkstyleMain
-            ./gradlew bootJar
-            docker build -t openmf/ph-ee-bill-pay:latest .
-            if [ "$CIRCLE_BRANCH" != "master" ]; then
-              PR_NUMBER=$(basename $CIRCLE_PULL_REQUEST)
-              PR_TITLE=$(curl -sSL "https://api.github.com/repos/openmf/$CIRCLE_PR_REPONAME/pulls/$PR_NUMBER" | jq -r '.title')
-              JIRA_STORY=$(echo $PR_TITLE | cut -d "[" -f2 | cut -d "]" -f1 | tr '[A-Z]' '[a-z]')
-              if [ -z "$JIRA_STORY" ]; then echo "Invalid PR title" && exit 1; else echo "Ticket NO: $JIRA_STORY"; fi
-              docker image tag openmf/$CIRCLE_PR_REPONAME:latest openmf/$CIRCLE_PR_REPONAME:$JIRA_STORY
-            fi
-
-      # Log in to DockerHub using environment variables
-      - run:
-          name: Login to DockerHub
-          command: echo "${DOCKERHUB_PASSWORD}" | docker login -u "${DOCKERHUB_USERNAME}" --password-stdin
-
-      # Push the Docker image to DockerHub
-      - run:
-          name: Push Docker image to DockerHub
-          command: |
-            if [ "$CIRCLE_BRANCH" = "master" ]; then
-            docker push openmf/ph-ee-bill-pay:latest
-            fi
-            if [ "$CIRCLE_BRANCH" != "master" ]; then
-            PR_NUMBER=$(basename $CIRCLE_PULL_REQUEST)
-            PR_TITLE=$(curl -sSL "https://api.github.com/repos/openmf/$CIRCLE_PR_REPONAME/pulls/$PR_NUMBER" | jq -r '.title')
-            JIRA_STORY=$(echo $PR_TITLE | cut -d "[" -f2 | cut -d "]" -f1 | tr '[A-Z]' '[a-z]')
-            docker push openmf/$CIRCLE_PR_REPONAME:${JIRA_STORY}
-            fi
-
+            ./gradlew clean bootJar
+      - docker-buildx/build-and-push:
+          # Using lowercase variables defined above
+          image-name: "$DOCKER_ORG_LOWER/$DOCKER_REPO_LOWER"
+          tag: "latest"
+          # Add dockerhub credentials if needed
+          # dockerhub-username: "$DOCKERHUB_USERNAME"
+          # dockerhub-password: "$DOCKERHUB_PASSWORD"
 workflows:
   version: 2
-  build-and-push:
+  build-and-push-pipeline:
     jobs:
+      # Build tags matching vX.Y.Z format
       - build_and_push_tag_image:
           filters:
             tags:
-              only: /^v\d+\.\d+\.\d+$/  # Match tags in the format v1.2.3
+              only: /^v\d+\.\d+\.\d+$/
+            branches:
+              ignore: /.*/
           context:
             - DOCKER
+      # Build any branch commit (except tags)
+      - build_and_push_branch_image:
+          filters:
+            tags:
+              ignore: /.*/
+            branches:
+              only: /.*/
+          context:
+            - DOCKER
+      # Build 'latest' only when the branch image succeeds AND it's the main/master branch
       - build_and_push_latest_image:
+          requires:
+            - build_and_push_branch_image
+          filters:
+            tags:
+              ignore: /.*/
+            branches:
+              only:
+                - main # Or your primary branch name like 'master'
           context:
             - DOCKER

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17
+FROM eclipse-temurin:17-jdk
 EXPOSE 8080
 
 COPY build/libs/*.jar ./

--- a/build.gradle
+++ b/build.gradle
@@ -287,7 +287,7 @@ configure(this) {
 
 
 group = 'org.mifos'
-version = '1.0.0-SNAPSHOT'
+version = '2.0.0.mifos-SNAPSHOT'
 sourceCompatibility = JavaVersion.VERSION_17
 targetCompatibility = JavaVersion.VERSION_17
 

--- a/build.gradle
+++ b/build.gradle
@@ -13,13 +13,16 @@ plugins {
 }
 
 repositories {
-    mavenLocal()
+    mavenCentral()
+    // mavenLocal()
     maven {
-        url = uri('https://repo.maven.apache.org/maven2')
+        url = uri('https://repo.maven.apache.org/maven2/')
     }
-
     maven {
-        url = uri('https://jfrog.sandbox.fynarfin.io/artifactory/fyn-libs-snapshot')
+        url = uri('https://mifos.jfrog.io/artifactory/phee-gradle-local')
+    }    
+    maven {
+        url = uri('https://mifos.jfrog.io/artifactory/mifosx-gradle-local')
     }
 }
 
@@ -51,7 +54,8 @@ ext {
 
 dependencies {
     implementation 'com.google.code.gson:gson:2.8.9'
-    implementation 'org.mifos:ph-ee-connector-common:1.8.1-SNAPSHOT'
+    implementation 'org.mifos:ph-ee-connector-common:1.8.1-gazelle'
+    // implementation 'org.mifos:ph-ee-connector-common:1.8.1-SNAPSHOT'
     implementation 'org.apache.camel.springboot:camel-spring-boot-starter:3.12.0'
     implementation('org.springframework.boot:spring-boot-starter-web:2.6.2')
     implementation "org.springframework.boot:spring-boot-starter-actuator:$springBootVersion"


### PR DESCRIPTION
## Summary

This release brings ph-ee-bill-pay to version 2.0.0.mifos-SNAPSHOT with Java 17 migration and updated build configuration for Mifos JFrog Artifactory.

### Key Changes

- **Java 17 migration**: Updated Dockerfile to use `eclipse-temurin:17-jdk` base image; updated CircleCI config
- **Mifos JFrog**: Updated `build.gradle` to resolve `connector-common` and other dependencies from Mifos JFrog Artifactory
- **Version**: Bumped to `2.0.0.mifos-SNAPSHOT`

### Test Plan

- [ ] Verify bill-pay service builds and starts correctly
- [ ] Confirm dependency resolution from Mifos JFrog Artifactory
- [ ] Confirm CircleCI pipeline passes with Java 17

🤖 Generated with [Claude Code](https://claude.com/claude-code)